### PR TITLE
feat: add subscription info to surge conf to implement surge config auto update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git clone https://github.com/vvbbnn00/WARP-Clash-API.git
 
 ### 3. [可选] 配置`SECRET_KEY`
 
-若您需要在公网上部署该项目，建议您配置`SECRET_KEY`。在项目目录下创建`.env.local`文件，写入如下内容：
+若您需要在公网上部署该项目，建议您配置`SECRET_KEY`与`PUBLIC_URL`。在项目目录下创建`.env.local`文件，写入如下内容：
 
 ```bash
 SECRET_KEY=your_secret_key
@@ -86,6 +86,7 @@ python3 app.py optimize
 | LOSS_THRESHOLD     | 10                                | 丢包率阈值，超过该阈值的`IP`将被剔除                                                                |
 | DELAY_THRESHOLD    | 500                               | 延迟阈值，超过该阈值的`IP`将被剔除                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP代理池地址，用于刷取`WARP+`流量，您可以自行搭建，参照[proxy_pool](https://github.com/jhao104/proxy_pool) |
+| PUBLIC_URL        | 无                                | 部署在公网上时，填写公网`IP`或域名，用于生成订阅链接  |
 
 ## 🗂️ 引用项目
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ python3 app.py optimize
 | LOSS_THRESHOLD     | 10                                | 丢包率阈值，超过该阈值的`IP`将被剔除                                                                |
 | DELAY_THRESHOLD    | 500                               | 延迟阈值，超过该阈值的`IP`将被剔除                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP代理池地址，用于刷取`WARP+`流量，您可以自行搭建，参照[proxy_pool](https://github.com/jhao104/proxy_pool) |
-| PUBLIC_URL        | 无                                | 部署在公网上时，填写公网`IP`或域名，用于生成订阅链接  |
+| PUBLIC_URL        | 无                                | 部署在公网上时，填写公网`IP`或域名，用于生成订阅链接，比如 `https://subs.zeabur.app`  |
 
 ## 🗂️ 引用项目
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ python3 app.py optimize
 | LOSS_THRESHOLD     | 10                                | 丢包率阈值，超过该阈值的`IP`将被剔除                                                                |
 | DELAY_THRESHOLD    | 500                               | 延迟阈值，超过该阈值的`IP`将被剔除                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP代理池地址，用于刷取`WARP+`流量，您可以自行搭建，参照[proxy_pool](https://github.com/jhao104/proxy_pool) |
-| PUBLIC_URL        | 无                                | 部署在公网上时，填写公网`IP`或域名，用于生成订阅链接，比如 `https://subs.zeabur.app`  |
+| PUBLIC_URL         | 无                                 | 部署在公网上时，填写公网`IP`或域名，用于生成订阅链接，比如 `https://subs.zeabur.app`                           |
 
 ## 🗂️ 引用项目
 

--- a/README_en.md
+++ b/README_en.md
@@ -56,7 +56,8 @@ docker-compose up -d
 
 ### 5. Obtain Subscription Link
 
-Visit `http://your_IP:21001`, enter the `SECRET_KEY` and `PUBLIC_URL` (if configured), and you can get the subscription link.
+Visit `http://your_IP:21001`, enter the `SECRET_KEY` and `PUBLIC_URL` (if configured), and you can get the subscription
+link.
 
 **🎉 Congratulations, you're all set!**
 
@@ -94,8 +95,7 @@ Here are the available environment variables:
 | LOSS_THRESHOLD     | 10                                | Packet loss threshold; IPs exceeding this threshold will be removed.                                                                                           |
 | DELAY_THRESHOLD    | 500                               | Delay threshold; IPs exceeding this threshold will be removed.                                                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP proxy pool address, used to get `WARP+` traffic. You can build it yourself, check [proxy_pool](https://github.com/jhao104/proxy_pool) for more information. |
-| PUBLIC_URL        | None                                | When deployed on the public network, fill in the public IP or domain name to generate subscription links. for example `https://subs.zeabur.app`  |
-
+| PUBLIC_URL         | None                              | When deployed on the public network, fill in the public IP or domain name to generate subscription links. for example `https://subs.zeabur.app`                |
 
 ## 🗂️ Attribution
 

--- a/README_en.md
+++ b/README_en.md
@@ -94,7 +94,7 @@ Here are the available environment variables:
 | LOSS_THRESHOLD     | 10                                | Packet loss threshold; IPs exceeding this threshold will be removed.                                                                                           |
 | DELAY_THRESHOLD    | 500                               | Delay threshold; IPs exceeding this threshold will be removed.                                                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP proxy pool address, used to get `WARP+` traffic. You can build it yourself, check [proxy_pool](https://github.com/jhao104/proxy_pool) for more information. |
-| PUBLIC_URL        | None                                | When deployed on the public network, fill in the public IP or domain name to generate subscription links.  |
+| PUBLIC_URL        | None                                | When deployed on the public network, fill in the public IP or domain name to generate subscription links. for example `https://subs.zeabur.app`  |
 
 
 ## 🗂️ Attribution

--- a/README_en.md
+++ b/README_en.md
@@ -56,7 +56,7 @@ docker-compose up -d
 
 ### 5. Obtain Subscription Link
 
-Visit `http://your_IP:21001`, enter the `SECRET_KEY` (if configured), and you can get the subscription link.
+Visit `http://your_IP:21001`, enter the `SECRET_KEY` and `PUBLIC_URL` (if configured), and you can get the subscription link.
 
 **🎉 Congratulations, you're all set!**
 
@@ -94,6 +94,8 @@ Here are the available environment variables:
 | LOSS_THRESHOLD     | 10                                | Packet loss threshold; IPs exceeding this threshold will be removed.                                                                                           |
 | DELAY_THRESHOLD    | 500                               | Delay threshold; IPs exceeding this threshold will be removed.                                                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP proxy pool address, used to get `WARP+` traffic. You can build it yourself, check [proxy_pool](https://github.com/jhao104/proxy_pool) for more information. |
+| PUBLIC_URL        | None                                | When deployed on the public network, fill in the public IP or domain name to generate subscription links.  |
+
 
 ## 🗂️ Attribution
 

--- a/config.py
+++ b/config.py
@@ -9,3 +9,4 @@ DO_GET_WARP_DATA = bool(os.environ.get('DO_GET_WARP_DATA')) or True
 PORT = int(os.environ.get('PORT')) if os.environ.get('PORT') else 3000
 HOST = os.environ.get('HOST') or '0.0.0.0'
 PROXY_POOL_URL = os.environ.get('PROXY_POOL_URL', 'https://getproxy.bzpl.tech/get/')
+PUBLIC_URL = os.environ.get('PUBLIC_URL') or None

--- a/config/surge-sub.txt
+++ b/config/surge-sub.txt
@@ -1,0 +1,4 @@
+#!MANAGED-CONFIG {PUBLIC_URL} interval=43200 strict=true
+# Surge 的规则配置手册: https://manual.nssurge.com/
+# Thanks @Hackl0us SS-Rule-Snippet
+# Thanks @CorrectRoadH WARP+ to Surge

--- a/services/subscription.py
+++ b/services/subscription.py
@@ -17,7 +17,7 @@ CLASH = json.load(open("./config/clash.json", "r", encoding="utf8"))
 SURGE = configparser.ConfigParser()
 SURGE.read("./config/surge.conf", encoding="utf8")
 SURGE_RULE = open("./config/surge-rule.txt", "r", encoding="utf8").read()
-
+SURGE_SUB = open("./config/surge-sub.txt", "r", encoding="utf8").read()
 
 def generateClashSubFile(account: Account = None,
                          logger=logging.getLogger(__name__),
@@ -165,5 +165,10 @@ def generateSurgeSubFile(account: Account = None,
         pass
     else:
         surge_ini += SURGE_RULE
+ 
+    print(PUBLIC_URL)
+    if PUBLIC_URL is not None:
+        # TODO: add default route and chagne url to default route
+        surge_ini = SURGE_SUB.replace("{PUBLIC_URL}",f"{PUBLIC_URL}/api/surge?best=false&randomName=true") + surge_ini
 
     return surge_ini

--- a/services/subscription.py
+++ b/services/subscription.py
@@ -74,7 +74,9 @@ def generateClashSubFile(account: Account = None,
     return clash_yaml
 
 
-def generateWireguardSubFile(account: Account = None, logger=logging.getLogger(__name__), best=False):
+def generateWireguardSubFile(account: Account = None,
+                             logger=logging.getLogger(__name__),
+                             best=False):
     """
     Generate Wireguard subscription file
     :param account:

--- a/services/subscription.py
+++ b/services/subscription.py
@@ -168,7 +168,6 @@ def generateSurgeSubFile(account: Account = None,
  
     print(PUBLIC_URL)
     if PUBLIC_URL is not None:
-        # TODO: add default route and chagne url to default route
-        surge_ini = SURGE_SUB.replace("{PUBLIC_URL}",f"{PUBLIC_URL}/api/surge?best=false&randomName=true") + surge_ini
+        surge_ini = SURGE_SUB.replace("{PUBLIC_URL}",f"{PUBLIC_URL}/surge") + surge_ini
 
     return surge_ini

--- a/services/web_service.py
+++ b/services/web_service.py
@@ -95,82 +95,49 @@ def attachEndpoints(app: Flask):
             'data': account.__dict__
         }
 
-    @app.route('/api/clash', methods=['GET'])
+    @app.route('/api/<string:sub_type>', methods=['GET'])
     @rateLimit()
     @authorized()
-    def httpClash():
+    def httpSubscription(sub_type: str):
         account = getCurrentAccount(logger)
-        best = request.args.get('best') or False
-        random_name = request.args.get('randomName').lower() == "true" or False
+        best = request.args.get('best', 'false').lower() == "true" or False
+        random_name = request.args.get('randomName', 'false').lower() == "true" or False
 
-        fileData = generateClashSubFile(account, logger, best=best, random_name=random_name)
-
-        headers = {
-            'Content-Type': 'application/x-yaml; charset=utf-8',
-            'Content-Disposition': f'attachment; filename=Clash-{fake.color_name()}.yaml',
-            "Subscription-Userinfo": f"upload=0; download={account.usage}; total={account.quota}; expire=253388144714"
-        }
-
-        response = make_response(fileData)
-        response.headers = headers
-
-        return response
-
-    @app.route('/api/wireguard', methods=['GET'])
-    @rateLimit()
-    @authorized()
-    def httpWireguard():
-        account = getCurrentAccount(logger)
-        best = request.args.get('best') or False
-
-        fileData = generateWireguardSubFile(account, logger, best=best)
-
-        headers = {
-            'Content-Type': 'application/x-conf; charset=utf-8',
-            'Content-Disposition': f'attachment; filename={fake.lexify("????????????").lower()}.conf'
-        }
-
-        response = make_response(fileData)
-        response.headers = headers
-
-        return response
-
-    @app.route('/api/only_proxies', methods=['GET'])
-    @rateLimit()
-    @authorized()
-    def httpOnlyProxies():
-        account = getCurrentAccount(logger)
-        best = request.args.get('best') or False
-        random_name = request.args.get('randomName').lower() == "true" or False
-
-        fileData = generateClashSubFile(account, logger, best=best, only_proxies=True, random_name=random_name)
-
-        response = make_response(fileData)
-        headers = {
-            'Content-Type': 'application/x-yaml; charset=utf-8',
-            'Content-Disposition': f'attachment; filename=Clash-{fake.color_name()}.yaml',
-            "Subscription-Userinfo": f"upload=0; download={account.usage}; total={account.quota}; expire=253388144714"
-        }
-
-        response.headers = headers
-
-        return response
-
-    @app.route('/api/surge', methods=['GET'])
-    @rateLimit()
-    @authorized()
-    def httpSurge():
-        account = getCurrentAccount(logger)
-        best = request.args.get('best') or False
-        random_name = request.args.get('randomName').lower() == "true" or False
-
-        fileData = generateSurgeSubFile(account, logger, best=best, random_name=random_name)
-
-        headers = {
-            'Content-Type': 'text/plain; charset=utf-8',
-            'Content-Disposition': 'attachment; filename=surge.conf',
-            "Subscription-Userinfo": f"upload=0; download={account.usage}; total={account.quota}; expire=253388144714"
-        }
+        if sub_type == "clash":  # Clash
+            fileData = generateClashSubFile(account, logger, best=best, only_proxies=False, random_name=random_name)
+            headers = {
+                'Content-Type': 'application/x-yaml; charset=utf-8',
+                'Content-Disposition': f'attachment; filename=Clash-{fake.color_name()}.yaml',
+                "Subscription-Userinfo": f"upload=0; download={account.usage}; total={account.quota}; "
+                                         f"expire=253388144714"
+            }
+        elif sub_type == "wireguard":  # Wireguard
+            fileData = generateWireguardSubFile(account, logger, best=best)
+            headers = {
+                'Content-Type': 'application/x-conf; charset=utf-8',
+                'Content-Disposition': f'attachment; filename={fake.lexify("????????????").lower()}.conf'
+            }
+        elif sub_type == "surge":  # Surge
+            fileData = generateSurgeSubFile(account, logger, best=best, random_name=random_name)
+            headers = {
+                'Content-Type': 'text/plain; charset=utf-8',
+                'Content-Disposition': 'attachment; filename=surge.conf',
+                "Subscription-Userinfo": f"upload=0; download={account.usage}; total={account.quota}; "
+                                         f"expire=253388144714"
+            }
+        elif sub_type == "only_proxies":  # Only proxies
+            fileData = generateClashSubFile(account, logger, best=best, only_proxies=True, random_name=random_name)
+            headers = {
+                'Content-Type': 'application/x-yaml; charset=utf-8',
+                'Content-Disposition': f'attachment; filename=Clash-{fake.color_name()}.yaml',
+                "Subscription-Userinfo": f"upload=0; download={account.usage}; total={account.quota}; "
+                                         f"expire=253388144714"
+            }
+        else:
+            return {
+                'code': 400,
+                'message': 'Unsupported sub type.'
+            }, 400
 
         response = make_response(fileData)
         response.headers = headers


### PR DESCRIPTION
# What does the PR do?
- add subscription head to surge config
- add a environment `PUBLIC_URL`

Because Surge need subscription to update config automation

# Other
I want to add some default route like `http://localhost:3000/surge` and `http://localhost:3000/clash` to get default config in next PR.

the PR is depend #22