### PR TITLE
docs: We have noticed that Quantumult currently does not support the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## 💡 特色功能
 
-- 💻 支持`Clash`、`Surge`、`Quantumult`、`Shadowrocket`等客户端
+- 💻 支持`Clash`、`Surge`、`Shadowrocket`等客户端
 - 🌏 支持`IP`选优
 - 🐋 支持`Docker compose`一键部署
 - 📕 全自动刷取`WARP+`流量，请求经过代理，防封`IP`

--- a/README_en.md
+++ b/README_en.md
@@ -17,7 +17,7 @@ high-speed `WARP+` node without extra hassle!
 
 ## 💡 Key Features
 
-- 💻 Supports clients such as `Clash`, `Surge`, `Quantumult`, `Shadowrocket`, etc.
+- 💻 Supports clients such as `Clash`, `Surge`, `Shadowrocket`, etc.
 - 🌏 Supports IP optimization.
 - 🐋 Supports one-click deployment using `Docker compose`.
 - 📕 Automatically replenishes `WARP+` traffic, requests are proxied, preserving your IP from getting blocked.


### PR DESCRIPTION
…Wireguard protocol, therefore we have decided to temporarily remove it from the readme document.