### PR TITLE
feat: allow to custom surge managed url

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ python3 app.py optimize
 | DELAY_THRESHOLD    | 500                               | 延迟阈值，超过该阈值的`IP`将被剔除                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP代理池地址，用于刷取`WARP+`流量，您可以自行搭建，参照[proxy_pool](https://github.com/jhao104/proxy_pool) |
 | PUBLIC_URL         | 无                                 | 部署在公网上时，填写公网`IP`或域名，用于生成订阅链接，比如 `https://subs.zeabur.app`                           |
-| SURGE_SUBSCRIPTION_URL | /api/surge                     | 被托管的`Surge`配置文件的位置，默认为`api/surge`，即`http://你的IP:21001/api/surge` |
+| SURGE_SUBSCRIPTION_URL | /api/surge                     | 被托管的`Surge`配置文件的位置，即`http://你的IP:21001/api/surge` |
 
 ## 🗂️ 引用项目
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ python3 app.py optimize
 | DELAY_THRESHOLD    | 500                               | 延迟阈值，超过该阈值的`IP`将被剔除                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP代理池地址，用于刷取`WARP+`流量，您可以自行搭建，参照[proxy_pool](https://github.com/jhao104/proxy_pool) |
 | PUBLIC_URL         | 无                                 | 部署在公网上时，填写公网`IP`或域名，用于生成订阅链接，比如 `https://subs.zeabur.app`                           |
-| SURGE_SUBSCRIPTION_URL | api/surge                     | 被托管的`Surge`配置文件的位置，默认为`api/surge`，即`http://你的IP:21001/api/surge` |
+| SURGE_SUBSCRIPTION_URL | /api/surge                     | 被托管的`Surge`配置文件的位置，默认为`api/surge`，即`http://你的IP:21001/api/surge` |
 
 ## 🗂️ 引用项目
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ python3 app.py optimize
 | DELAY_THRESHOLD    | 500                               | 延迟阈值，超过该阈值的`IP`将被剔除                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP代理池地址，用于刷取`WARP+`流量，您可以自行搭建，参照[proxy_pool](https://github.com/jhao104/proxy_pool) |
 | PUBLIC_URL         | 无                                 | 部署在公网上时，填写公网`IP`或域名，用于生成订阅链接，比如 `https://subs.zeabur.app`                           |
+| SURGE_SUBSCRIPTION_URL | api/surge                     | 被托管的`Surge`配置文件的位置，默认为`api/surge`，即`http://你的IP:21001/api/surge` |
 
 ## 🗂️ 引用项目
 

--- a/README_en.md
+++ b/README_en.md
@@ -96,7 +96,7 @@ Here are the available environment variables:
 | DELAY_THRESHOLD    | 500                               | Delay threshold; IPs exceeding this threshold will be removed.                                                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP proxy pool address, used to get `WARP+` traffic. You can build it yourself, check [proxy_pool](https://github.com/jhao104/proxy_pool) for more information. |
 | PUBLIC_URL         | None                              | When deployed on the public network, fill in the public IP or domain name to generate subscription links. for example `https://subs.zeabur.app`                |
-| SURGE_SUBSCRIPTION_URL | /api/surge                     | The location of the hosted Surge configuration file, which by default is api/surge, i.e., `http://yourIP:21001/api/surge`. |
+| SURGE_SUBSCRIPTION_URL | /api/surge                     | The location of the hosted Surge configuration file, i.e., `http://yourIP:21001/api/surge`. |
 
 
 ## 🗂️ Attribution

--- a/README_en.md
+++ b/README_en.md
@@ -96,7 +96,7 @@ Here are the available environment variables:
 | DELAY_THRESHOLD    | 500                               | Delay threshold; IPs exceeding this threshold will be removed.                                                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP proxy pool address, used to get `WARP+` traffic. You can build it yourself, check [proxy_pool](https://github.com/jhao104/proxy_pool) for more information. |
 | PUBLIC_URL         | None                              | When deployed on the public network, fill in the public IP or domain name to generate subscription links. for example `https://subs.zeabur.app`                |
-| SURGE_SUBSCRIPTION_URL | api/surge                     | The location of the hosted Surge configuration file, which by default is api/surge, i.e., `http://yourIP:21001/api/surge`. |
+| SURGE_SUBSCRIPTION_URL | /api/surge                     | The location of the hosted Surge configuration file, which by default is api/surge, i.e., `http://yourIP:21001/api/surge`. |
 
 
 ## 🗂️ Attribution

--- a/README_en.md
+++ b/README_en.md
@@ -96,6 +96,8 @@ Here are the available environment variables:
 | DELAY_THRESHOLD    | 500                               | Delay threshold; IPs exceeding this threshold will be removed.                                                                                                 |
 | PROXY_POOL_URL     | `https://getproxy.bzpl.tech/get/` | IP proxy pool address, used to get `WARP+` traffic. You can build it yourself, check [proxy_pool](https://github.com/jhao104/proxy_pool) for more information. |
 | PUBLIC_URL         | None                              | When deployed on the public network, fill in the public IP or domain name to generate subscription links. for example `https://subs.zeabur.app`                |
+| SURGE_SUBSCRIPTION_URL | api/surge                     | The location of the hosted Surge configuration file, which by default is api/surge, i.e., `http://yourIP:21001/api/surge`. |
+
 
 ## 🗂️ Attribution
 

--- a/config.py
+++ b/config.py
@@ -10,3 +10,4 @@ PORT = int(os.environ.get('PORT')) if os.environ.get('PORT') else 3000
 HOST = os.environ.get('HOST') or '0.0.0.0'
 PROXY_POOL_URL = os.environ.get('PROXY_POOL_URL', 'https://getproxy.bzpl.tech/get/')
 PUBLIC_URL = os.environ.get('PUBLIC_URL') or None
+SURGE_SUBSCRIPTION_URL = os.environ.get('SURGE_SUBSCRIPTION_URL') or 'api/surge'

--- a/config.py
+++ b/config.py
@@ -10,4 +10,4 @@ PORT = int(os.environ.get('PORT')) if os.environ.get('PORT') else 3000
 HOST = os.environ.get('HOST') or '0.0.0.0'
 PROXY_POOL_URL = os.environ.get('PROXY_POOL_URL', 'https://getproxy.bzpl.tech/get/')
 PUBLIC_URL = os.environ.get('PUBLIC_URL') or None
-SURGE_SUBSCRIPTION_URL = os.environ.get('SURGE_SUBSCRIPTION_URL') or 'api/surge'
+SURGE_SUBSCRIPTION_URL = os.environ.get('SURGE_SUBSCRIPTION_URL') or '/api/surge'

--- a/services/subscription.py
+++ b/services/subscription.py
@@ -185,6 +185,6 @@ def generateSurgeSubFile(account: Account = None,
         public_url = request.url_root[:-1]
 
     surge_ini = SURGE_SUB.replace("{PUBLIC_URL}",
-                                  f"{public_url}/{SURGE_SUBSCRIPTION_URL}") + surge_ini
+                                  f"{public_url}{SURGE_SUBSCRIPTION_URL}") + surge_ini
 
     return surge_ini

--- a/services/subscription.py
+++ b/services/subscription.py
@@ -185,6 +185,6 @@ def generateSurgeSubFile(account: Account = None,
         public_url = request.url_root[:-1]
 
     surge_ini = SURGE_SUB.replace("{PUBLIC_URL}",
-                                  f"{public_url}/api/surge?best={str(best).lower()}&randomName={str(random_name).lower()}") + surge_ini
+                                  f"{public_url}/{SURGE_SUBSCRIPTION_URL}") + surge_ini
 
     return surge_ini


### PR DESCRIPTION
# What does the PR do?
add a environment var to custom the surge managed url.

In general, the surge managed url is `http://yourIP:21001/api/surge`. But in some cases. We need add a reverse proxy in front of WARP clash API. the url may like `https://sub.xxxx.xxx` or `https://sub.xxxx.xxx/surge`.

So in the point view of product and user. I had to join the feature to WARP Clash API. Although it add some complexity.