### PR TITLE
dockerfile for armhf linux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ README.md
 LICENSE
 logs/*.log
 account/*.json
+.idea
+venv

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -30,7 +30,7 @@ jobs:
           tags: |
             type=sha,format=short
 
-      - name: Build and push
+      - name: Build and push (Dockerfile)
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -42,6 +42,19 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: GITHUB_ACTIONS=true
           platforms: linux/amd64,linux/arm64
+
+      - name: Build and push (Dockerfile.armhf)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.armhf
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: GITHUB_ACTIONS=true
+          platforms: linux/arm/v7
 
       - name: Image digest
         run: echo ${{ steps.meta.outputs.digest }}

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,25 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+
+# Install Python, pip, necessary build dependencies,in one layer
+RUN apt-get update && \
+    apt-get install -y libffi-dev libssl-dev build-essential && \
+    printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the rest of the code
+COPY . .
+RUN chmod +x ./scripts/*.sh
+
+# Set environment variables
+ENV RUN_IN_DOCKER=true
+
+CMD ["/bin/sh", "./scripts/run.sh"]


### PR DESCRIPTION
For local build behind GFW, use proxy as environment variable passing: 
```shell
docker build --build-arg http_proxy='http://localhost:7890' --build-arg https_proxy='http://localhost:7890' --build-arg all_proxy='socks5://localhost:7890'  -f Dockerfile.armhf -t $image_id .
```

Example image: https://hub.docker.com/r/yaoyinying/warp-clash-api-armhf

 IP optimizing is not work due to the lack of build of `warp-yxip` tool.

see here: https://gitlab.com/Misaka-blog/warp-script/-/tree/main/files/warp-yxip?ref_type=heads