### PR TITLE
Fix: 修正错误字段

### DIFF
--- a/config/clash-meta.json
+++ b/config/clash-meta.json
@@ -4,7 +4,7 @@
   "allow-lan": false,
   "unified-delay": true,
   "keep-alive-interval": 300,
-  "mode": "Rule",
+  "mode": "rule",
   "log-level": "info",
   "external-controller": "127.0.0.1:9090",
   "dns": {

--- a/config/clash.json
+++ b/config/clash.json
@@ -2,7 +2,7 @@
   "mixed-port": 7890,
   "socks-port": 7891,
   "allow-lan": false,
-  "mode": "Rule",
+  "mode": "rule",
   "log-level": "info",
   "external-controller": "127.0.0.1:9090",
   "dns": {


### PR DESCRIPTION
mode字段的rule应该为全小写，不应该有首字母大写

_Ref: https://wiki.metacubex.one/config/general/#_4_