### PR TITLE
use Aliyun for PyPI source when not in Github Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM python:3.11-alpine
 WORKDIR /app
 
 # Install dependencies for building some Python packages
-# Check if in Github Actions, if not, change Alpine source to Aliyun
+# Check if in Github Actions, if not, change Alpine source and PyPI source to Aliyun
 ARG GITHUB_ACTIONS
 RUN if [ "$GITHUB_ACTIONS" != "true" ]; then \
         sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories; \
+        pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/; \
     fi
 RUN apk add --no-cache bash build-base libffi-dev openssl-dev gcompat
 


### PR DESCRIPTION
use Aliyun for PyPI source when not in Github Actions to speed up self-building docker image